### PR TITLE
Feature/auth rate limiting

### DIFF
--- a/backend/application_errors/application_errors.go
+++ b/backend/application_errors/application_errors.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"github.com/cass-dlcm/pomodoro_tasks/graph/model"
 	"log"
+	"runtime/debug"
 	"time"
 )
 
 var ErrNoUser = errors.New("no user found")
 var ErrUserExists = errors.New("user already exists")
-var ErrIncorrectPass = errors.New("incorrect password")
 var ErrPleaseAuth = errors.New("please log in and try again")
 var ErrNoDependency = errors.New("no dependency found")
 var ErrDependencyFound = errors.New("dependency found")
@@ -49,5 +49,24 @@ func ErrCannotFetchTodoListNoPrint(item int64) error {
 
 func ErrUnspecified(err error) error {
 	log.Println(err)
+	debug.PrintStack()
 	return fmt.Errorf("%v: an unspecified error has occured\nplease let the admin know and give this timestamp", time.Now().Format("2006-01-02 15:04:05"))
+}
+
+func ErrIncorrectPass(username string, timeout int64) error {
+	log.Println(ErrIncorrectPassNoPrint(username, timeout).Error())
+	return ErrIncorrectPassNoPrint(username, timeout)
+}
+
+func ErrIncorrectPassNoPrint(username string, timeout int64) error {
+	return fmt.Errorf("incorrect password for user %s, please try again in %d seconds", username, timeout)
+}
+
+func ErrPleaseWaitForAuth(username string, timeout int64) error {
+	log.Println(ErrPleaseWaitForAuthNoPrint(username, timeout).Error())
+	return ErrPleaseWaitForAuthNoPrint(username, timeout)
+}
+
+func ErrPleaseWaitForAuthNoPrint(username string, timeout int64) error {
+	return fmt.Errorf("user %s is on login timeout, please try again in %d seconds", username, timeout)
 }

--- a/db_migrations/user_auth_rate_limits.sql
+++ b/db_migrations/user_auth_rate_limits.sql
@@ -1,0 +1,10 @@
+create table user_auth_rate_limits
+(
+    user_id int not null,
+    ip_addr varchar(45) not null,
+    failed_auth_count int not null,
+    last_failed_auth datetime not null,
+    constraint user_auth_rate_limits_pk
+        primary key (user_id, ip_addr)
+);
+

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -207,7 +207,7 @@ func (*mutationResolver) SignIn(ctx context.Context, user model.UserAuth) (*stri
 	count, lastFailedLogin, err := db.GetTimeout(userInfo.ID, ctx.Value(auth.ContextKey("ip")).(string))
 	if err == nil {
 		if time.Now().Before(lastFailedLogin.Add(time.Second * 1 << *count)) {
-			return nil, application_errors.ErrPleaseWaitForAuth(user.Name, int64(math.Ceil(lastFailedLogin.Add(time.Second*2<<*count).Sub(time.Now()).Seconds())))
+			return nil, application_errors.ErrPleaseWaitForAuth(user.Name, int64(math.Ceil(time.Until(lastFailedLogin.Add(time.Second*2<<*count)).Seconds())))
 		}
 	}
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"log"
+	"math"
 	"time"
 
 	"github.com/cass-dlcm/pomodoro_tasks/backend/application_errors"
@@ -196,10 +197,36 @@ func (*mutationResolver) SignIn(ctx context.Context, user model.UserAuth) (*stri
 	if auth.GetUsername(ctx) != "" {
 		return nil, application_errors.ErrAlreadySignedIn
 	}
-	if err := auth.CheckPassword(user); err != nil {
-		if errors.Is(err, application_errors.ErrNoUser) || errors.Is(err, application_errors.ErrIncorrectPass) {
+	userInfo, err := db.GetUserUsername(user.Name)
+	if err != nil {
+		if errors.Is(err, application_errors.ErrNoUser) {
 			return nil, err
 		}
+		return nil, application_errors.ErrUnspecified(err)
+	}
+	count, lastFailedLogin, err := db.GetTimeout(userInfo.ID, ctx.Value(auth.ContextKey("ip")).(string))
+	if err == nil {
+		if time.Now().Before(lastFailedLogin.Add(time.Second * 1 << *count)) {
+			return nil, application_errors.ErrPleaseWaitForAuth(user.Name, int64(math.Ceil(lastFailedLogin.Add(time.Second*2<<*count).Sub(time.Now()).Seconds())))
+		}
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, application_errors.ErrUnspecified(err)
+	}
+	if count == nil {
+		countVal := 0
+		count = &countVal
+	}
+	if err := auth.CheckPassword(user, count); err != nil {
+		if err.Error() == application_errors.ErrIncorrectPassNoPrint(user.Name, 1<<(*count+1)).Error() {
+			if err := db.IncrementTimeout(userInfo.ID, ctx.Value(auth.ContextKey("ip")).(string), *count+1); err != nil {
+				return nil, application_errors.ErrUnspecified(err)
+			}
+			return nil, err
+		}
+		return nil, application_errors.ErrUnspecified(err)
+	}
+	if err := db.DeleteTimeout(userInfo.ID, ctx.Value(auth.ContextKey("ip")).(string)); err != nil {
 		return nil, application_errors.ErrUnspecified(err)
 	}
 	token, err := auth.CreateToken(user.Name)


### PR DESCRIPTION
This is a security feature, adding exponential rate limiting to login attempts for unique combinations of IP address and user account.

The use of IP address and user account combo is so that a malicious actor cannot universally lock out users.

By exponential rate limiting, it's 2^(n-1) where n is the number of consecutive failed attempts at logging into a user account from an IP address.

Failed attempts are logged in the database so that there's persistance for timeouts beyond server reboots.